### PR TITLE
update pools.json URL

### DIFF
--- a/spec/spec.md
+++ b/spec/spec.md
@@ -533,8 +533,7 @@ We will need to create a new DB table called pool for this. Schema is shared bel
 
 - In the main service for forkscanner, send a get request to below URL to get a json of active pools and save them in DB according to schema provided.
 
-https://raw.githubusercontent.com/0xB10C/known-mining-pools/master/pools.json
-
+https://raw.githubusercontent.com/bitcoin-data/mining-pools/generated/pools.json
 
 ### Perform Calculations.
 

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -42,7 +42,7 @@ const STALE_WINDOW: i64 = 100;
 const DOUBLE_SPEND_RANGE: i64 = 30;
 const REACHABLE_CHECK_INTERVAL: i64 = 10;
 const MINER_POOL_INFO: &str =
-    "https://raw.githubusercontent.com/0xB10C/known-mining-pools/master/pools.json";
+    "https://raw.githubusercontent.com/bitcoin-data/mining-pools/generated/pools.json";
 const SATOSHI_TO_BTC: i64 = 100_000_000;
 
 type ForkScannerResult<T> = Result<T, ForkScannerError>;


### PR DESCRIPTION
I've recently moved the known-mining-pools to the bitcoin-data org on GitHub. The old URL 404's.

https://raw.githubusercontent.com/0xB10C/known-mining-pools/master/pools.json

The new URL is (and shouldn't change anymore):

https://raw.githubusercontent.com/bitcoin-data/mining-pools/generated/pools.json